### PR TITLE
Use "docs/" instead of mock site folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
         'react/jsx-uses-vars': 'error',
         'react/prop-types': 0,
     },
-    'ignorePatterns': ['backend_src/**', 'venv/**', 'mock_site_dist/'],
+    'ignorePatterns': ['backend_src/**', 'venv/**', 'docs/'],
 
     'settings': {
         'react': {'version': 'detect'}

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ build/
 dist/
 
 # Mock Files
-mock_site_dist/
+docs/


### PR DESCRIPTION
GitHub pages currently only supports `/(root)` and `docs/`, switching to `docs/`